### PR TITLE
prune the build cache along with images

### DIFF
--- a/vars/cleanImages.groovy
+++ b/vars/cleanImages.groovy
@@ -7,5 +7,6 @@ def cleanDocker(String name = ''){
 def call(String name = ''){
     sh 'docker container prune -f'
     sh 'docker image prune --force --filter "until=360h"'
+    sh 'docker builder prune --force --filter "until=360h"'
     cleanDocker(name)
 }


### PR DESCRIPTION
We've been running out of disk space on the new Jenkins server frequently. At first, I thought our image cleaning might not be working, but the issue actually seems to be our _build cache_ filling up. The build cache gets cleaned up by `docker system prune`, but not by `docker image prune`, which would explain why our cleaning commands aren't touching it.

There _should_ be automatic garbage collection that runs periodically and prevents the disk from filling up, but that doesn't seem to be happening. I'm still not sure why. I considered manually setting a garbage collection policy in a Docker config file, but integrating the build cache cleaning into the pipeline seems like a better idea long-term because it will carry over to future Jenkins servers without being an additional manual step to have to remember to set up. 

All that said, my thinking is that we could try running `docker builder prune` on the same schedule as `docker image prune`: We clean up images older than 15 days, and then clean the build cache of anything that was associated with those images and is now dangling. This might not end up being frequent enough, but since the build cache does speed up builds, I don't want to clear it too aggressively. I'd like to give this timing a shot and see how it goes; we can always iterate if it proves to be too lax.